### PR TITLE
tmp/pids/server.pidが残らないようにdocker-cmpose.ymlを修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   web:
     build: .
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    command: /bin/sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/app
     ports:


### PR DESCRIPTION
## やったこと

docker-compose upした時にtmp/pids/server.pidが残っているために「A server is already running.」と怒られるので、

立ち上げ時に次のコマンド`rm -f tmp/pids/server.pid`を実行するようにdocker-compose.ymlのcommandを修正。